### PR TITLE
Fix additional headers and root category selection

### DIFF
--- a/Console/Command/CategoriesCommand.php
+++ b/Console/Command/CategoriesCommand.php
@@ -142,7 +142,7 @@ class CategoriesCommand extends Command
                 throw new LocalizedException(__('Please specify path to file! (eg. "var/import/categories.csv")'));
             }
             $additionalHeadersDefinedByUser = explode(',', $input->getOption('additional'));
-            $this->additionalHeaders = array_merge($this->additionalHeaders, $additionalHeadersDefinedByUser);
+            $this->additionalHeaders = array_filter(array_merge($this->additionalHeaders, $additionalHeadersDefinedByUser));
 
             $file = $this->directoryList->getRoot() . '/' . $path;
 
@@ -264,7 +264,8 @@ class CategoriesCommand extends Command
         $category->setIsActive($this->getOptionalAttributeValue($data, 'is_active', true));
         $category->setIncludeInMenu($this->getOptionalAttributeValue($data, 'include_in_menu', true));
         if ($isParent) {
-            $category->setParentId(2);
+            $rootCategoryId = $this->storeManager->getStore(1)->getRootCategoryId();
+            $category->setParentId($rootCategoryId);
         } else {
             $categoryCollection = $this->getCategoryFromCollectionByOldId($categoryFactory, $data, 'parent_id');
             if ($categoryCollection->getSize()) {


### PR DESCRIPTION
* The additional headers generated array can generate empty values (which lend later to warning or errors). We use array_filter to remove empty values.
* If no parent id is selected, instead of automatically selecting '2' as category root, we check what the category root for the default store view is. We could even ask this value as parameter (TODO)