### PR TITLE
Fix for PHP 8.2 compatibility (Magento 2.4.6-p3 tested)

### DIFF
--- a/Console/Command/CategoriesCommand.php
+++ b/Console/Command/CategoriesCommand.php
@@ -141,7 +141,7 @@ class CategoriesCommand extends Command
             if (!$path) {
                 throw new LocalizedException(__('Please specify path to file! (eg. "var/import/categories.csv")'));
             }
-            $additionalHeadersDefinedByUser = explode(',', $input->getOption('additional'));
+            $additionalHeadersDefinedByUser = $input->getOption('additional') ? explode(',', $input->getOption('additional')) : [];
             $this->additionalHeaders = array_merge($this->additionalHeaders, $additionalHeadersDefinedByUser);
 
             $file = $this->directoryList->getRoot() . '/' . $path;
@@ -306,11 +306,12 @@ class CategoriesCommand extends Command
     protected function mapHeaders($row)
     {
         $headers = array_merge($this->requiredHeaders, $this->optionalHeaders, $this->additionalHeaders);
+    
+        $this->headersMap = []; // Initialize headersMap as an empty array
+    
         foreach ($row as $key => $item) {
-            foreach ($headers as $header) {
-                if($item == $header) {
-                    $this->headersMap[$header] = $key;
-                }
+            if (in_array($item, $headers)) {
+                $this->headersMap[$item] = $key;
             }
         }
     }

--- a/Setup/InstallData.php
+++ b/Setup/InstallData.php
@@ -6,7 +6,6 @@ use Magento\Framework\Setup\InstallDataInterface;
 use Magento\Framework\Setup\ModuleContextInterface;
 use Magento\Framework\Setup\ModuleDataSetupInterface;
 
-
 class InstallData implements InstallDataInterface
 {
     /**
@@ -15,9 +14,14 @@ class InstallData implements InstallDataInterface
     private $eavSetupFactory;
 
     /**
-     * @var \Magento\Eav\Setup\EavSetup $eavSetup
+     * @var \Magento\Eav\Setup\EavSetup
      */
     private $eavSetup;
+
+    /**
+     * @var string
+     */
+    private $entityType;
 
     /**
      * @param \Magento\Eav\Setup\EavSetupFactory $eavSetupFactory


### PR DESCRIPTION
# PR Summary
This pull request addresses several issues in the InstallData.php and CategoriesCommand.php files, ensuring compatibility with PHP 8.2 and fixing potential errors when importing categories (tested with Magento 2.4.6-p3). Additionally, it resolves deprecated functionality warnings.

# Changes

## InstallData.php
- Added a private property `$entityType` to store the entity type.
- Fixed the deprecated functionality warning by explicitly declaring the `$entityType` property.

## CategoriesCommand.php
- Modified the `configure` method to handle the case when 'additional' option is not provided.
- Updated the `mapHeaders` method to initialize `$this->headersMap` as an empty array.
- Refactored the header mapping process for better readability and compatibility.
- Improved handling of optional headers defined by the user.
- Adjusted the check for the existence of the file.

# Fixes
- Addressed the deprecated functionality warning in InstallData.php related to the dynamic property creation.
https://github.com/macopedia/CategoryImporter/issues/11
- Resolved PHP 8.2 error related to the `explode` function in CategoriesCommand.php.
`Deprecated Functionality: explode(): Passing null to parameter #2 ($string) of type string is deprecated in CategoriesCommand.php on line 144`
```
There is an error in app/code/Macopedia/CategoryImporter/Console/Command/CategoriesCommand.php at line: 159
array_key_exists(): Argument #2 ($array) must be of type array, null given#0 app/code/Macopedia/CategoryImporter/Console/Command/CategoriesCommand.php(159): array_key_exists()
#1 vendor/symfony/console/Command/Command.php(298): Macopedia\CategoryImporter\Console\Command\CategoriesCommand->execute()
#2 vendor/magento/framework/Interception/Interceptor.php(58): Symfony\Component\Console\Command\Command->run()
#3 vendor/magento/framework/Interception/Interceptor.php(138): Macopedia\CategoryImporter\Console\Command\CategoriesCommand\Interceptor->___callParent()
#4 vendor/magento/framework/Interception/Interceptor.php(153): Macopedia\CategoryImporter\Console\Command\CategoriesCommand\Interceptor->Magento\Framework\Interception\{closure}()
#5 generated/code/Macopedia/CategoryImporter/Console/Command/CategoriesCommand/Interceptor.php(23): Macopedia\CategoryImporter\Console\Command\CategoriesCommand\Interceptor->___callPlugins()
#6 vendor/symfony/console/Application.php(1040): Macopedia\CategoryImporter\Console\Command\CategoriesCommand\Interceptor->run()
#7 vendor/symfony/console/Application.php(301): Symfony\Component\Console\Application->doRunCommand()
#8 vendor/magento/framework/Console/Cli.php(116): Symfony\Component\Console\Application->doRun()
#9 vendor/symfony/console/Application.php(171): Magento\Framework\Console\Cli->doRun()
#10 bin/magento(23): Symfony\Component\Console\Application->run()
#11 {main}
```

# Testing
Tested successfully with Magento 2.4.6-p3 and PHP 8.2 by enabling the extension and importing categories with no deprecated warnings nor errors.